### PR TITLE
Resolve some NU1608 warnings in the HangfireApplications.API.csproj

### DIFF
--- a/HangfireApplications.API/HangfireApplications.API.csproj
+++ b/HangfireApplications.API/HangfireApplications.API.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.7.9" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.18" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.19" />
-    <PackageReference Include="Hangfire.SqlServer" Version="1.7.19" />
+    <PackageReference Include="Hangfire" Version="1.7.24" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.24" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.7.24" />
     <PackageReference Include="SendGrid" Version="9.22.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the HangfireApplications.API.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Hangfire 1.7.9 requires Hangfire.Core (= 1.7.9)，but version Hangfire.Core 1.7.19 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Hangfire 1.7.9 requires Hangfire.SqlServer (= 1.7.9)，but version Hangfire.SqlServer 1.7.19 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Hangfire 1.7.9 requires Hangfire.AspNetCore (= 1.7.9)，but version Hangfire.AspNetCore 1.7.18 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Hangfire.AspNetCore 1.7.18 requires Hangfire.Core (= 1.7.18)，but version Hangfire.Core 1.7.19 was resolved.`	

This fix can remove this warnings from HangfireApplications's dependency graph.
Hope the PR can help you.

Best regards,
sucrose